### PR TITLE
Add KeepNTruncator + fix qubit ordering for qiskit backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ FetchContent_Declare(
 FetchContent_Declare(
 		propauli
 		GIT_REPOSITORY https://github.com/zefresk/propauli.git
-		GIT_TAG v2.0.2
+		GIT_TAG v2.1.0
 )
 
 FetchContent_MakeAvailable(pybind11 propauli)

--- a/docs/guides/how_to_circuit.rst
+++ b/docs/guides/how_to_circuit.rst
@@ -19,3 +19,9 @@ number of qubits and then add gates sequentially. Finally, you run the circuit o
    :dedent: 4
 
 
+.. NOTE::
+        :py:class:`~pyrauli.Circuit` supports all Pauli gates (I, X, Y, Z), the Hadamard gate (H), the CNOT gate (CX) and the RZ(:math:`\theta`) gate. 
+
+
+.. TIP::
+        For more complex gates, you may use the Qiskit transpiler on :py:class:`~Pbackend`. See :doc:`../guides/how_to_qiskit`.

--- a/docs/guides/how_to_complexity.rst
+++ b/docs/guides/how_to_complexity.rst
@@ -30,6 +30,7 @@ Available truncators
 * :py:class:`~pyrauli.CoefficientTruncator`: truncate terms with absolute coefficient value below set threshold.
 * :py:class:`~pyrauli.WeightTruncator`: truncate terms with Pauli weight above set threshold.
 * :py:class:`~pyrauli.LambdaTruncator`: truncate terms if they match a predicate (Python function or lambda).
+* :py:class:`~pyrauli.KeepNTruncator`: truncate least significant terms if their number exceed a threshold. (Keep at most N different terms)
 * :py:class:`~pyrauli.MultiTruncator`: Combine a list of truncators into one.
 
 

--- a/docs/guides/how_to_complexity.rst
+++ b/docs/guides/how_to_complexity.rst
@@ -12,7 +12,7 @@ manage this complexity automatically during a :py:class:`~pyrauli.Circuit.run()`
 Remove small coefficients
 -------------------------
 
-**Solution:** Use a :py:class:`~pyrauli.CoefficientTruncator`.
+Use a :py:class:`~pyrauli.CoefficientTruncator`.
 
 This truncator removes any Pauli terms whose coefficient magnitude is below a
 given threshold.
@@ -23,10 +23,20 @@ given threshold.
    :end-before: # [truncator_coeff]
    :dedent: 4
 
+Available truncators
+--------------------
+
+* :py:class:`~pyrauli.NeverTruncator`: never truncate observable.
+* :py:class:`~pyrauli.CoefficientTruncator`: truncate terms with absolute coefficient value below set threshold.
+* :py:class:`~pyrauli.WeightTruncator`: truncate terms with Pauli weight above set threshold.
+* :py:class:`~pyrauli.LambdaTruncator`: truncate terms if they match a predicate (Python function or lambda).
+* :py:class:`~pyrauli.MultiTruncator`: Combine a list of truncators into one.
+
+
 Using a custom Truncator with your own logic
 --------------------------------------------
 
-**Solution:** Use a :py:class:`~pyrauli.LambdaTruncator`.
+Use a :py:class:`~pyrauli.LambdaTruncator`.
 
 This allows you to provide a custom Python function that filters the terms.
 
@@ -37,12 +47,12 @@ This allows you to provide a custom Python function that filters the terms.
    :dedent: 4
 
 .. NOTE::
-   This truncator removes :py:class:`~pyrauli.PauliTerm` containing :math:`Y`. However, this is not an efficient.
+   This truncator removes :py:class:`~pyrauli.PauliTerm` containing :math:`Y`. However, this is not very efficient.
 
 Controlling when truncation is applied
 --------------------------------------
 
-**Solution:** Use a :py:class:`~pyrauli.SchedulingPolicy`.
+Use a :py:class:`~pyrauli.SchedulingPolicy`.
 
 Scheduling Policies give you fine-grained control over when a :py:class:`~pyrauli.Truncator` is
 applied during the simulation. It can query a :py:class:`~pyrauli.SimulationState` object and other information to make a decision.

--- a/docs/guides/how_to_qiskit.rst
+++ b/docs/guides/how_to_qiskit.rst
@@ -27,6 +27,9 @@ The :py:class:`~pyrauli.PBackend` class allows you to use ``pyrauli`` as a backe
 Qiskit ecosystem, enabling you to **transpile** and run circuits defined in Qiskit on the
 ``pyrauli`` simulator.
 
+.. IMPORTANT::
+   If your Qiskit circuit uses unsupported gates, you need to transpile it, as you would for any other backend.
+
 Here is an example of transpilation to :py:class:`~pyrauli.PBackend`, relying on Qiskit ``PassManager``:
 
 .. literalinclude:: /../tests/test_backend.py
@@ -56,3 +59,13 @@ the hood.
    :start-after: # [estimator_complex]
    :end-before: # [estimator_complex]
    :dedent: 4
+
+Qiskit and reverse qubit ordering
+---------------------------------
+
+Qiskit uses reverse qubit ordering, while ``pyrauli`` use normal ordering. :py:class:`~pyrauli.from_qiskit` will not reverse the order of the qubit or Observable unless the `reverse=True` parameter is used.
+
+However, when a qiskit observable is passed to the `.run` method, it will be reversed so that the output result match the output you would get on any other qiskit backend.
+
+.. IMPORTANT::
+   You don't need to do anything different if using the qiskit compatible backend and qiskit observable. However, you may need to reverse the observable ordering when using :py:class:`~pyrauli.Circuit` and :py:class:`~pyrauli.from_qiskit` directly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "pyrauli"
-version = "0.2.1"
+version = "0.3.0"
 description = "A very fast and easy to use Quantum circuit simulator relying on Pauli propagation. Compatible with qiskit."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/pyrauli/_core/bindings.cpp
+++ b/src/pyrauli/_core/bindings.cpp
@@ -29,6 +29,7 @@ using SchedulingPolicyPtr = std::shared_ptr<SchedulingPolicy>;
 using CoeffTruncatorPtr = std::shared_ptr<CoefficientTruncator<coeff_t>>;
 using WeightTruncatorPtr = std::shared_ptr<WeightTruncator>;
 using NeverTruncatorPtr = std::shared_ptr<NeverTruncator>;
+using KeepNTruncatorPtr = std::shared_ptr<KeepNTruncator>;
 using NeverPolicyPtr = std::shared_ptr<NeverPolicy>;
 using AlwaysBeforePolicyPtr = std::shared_ptr<AlwaysBeforeSplittingPolicy>;
 using AlwaysAfterPolicyPtr = std::shared_ptr<AlwaysAfterSplittingPolicy>;
@@ -210,6 +211,10 @@ PYBIND11_MODULE(_core, m) {
 		.def(py::init<size_t>());
 	py::class_<NeverTruncator, Truncator<coeff_t>, NeverTruncatorPtr>(m, "NeverTruncator",
 									  "A truncator that never removes any terms.")
+		.def(py::init<>());
+	py::class_<KeepNTruncator, KeepNTruncator<coeff_t>, KeepNTruncatorPtr>(
+		m, "KeepNTruncator",
+		"A truncator that removes least significant Pauli Terms, when their numbers is above a threshold.")
 		.def(py::init<>());
 	py::class_<LambdaTruncator, Truncator<coeff_t>, LambdaTruncatorPtr>(
 		m, "LambdaTruncator", "A truncator that uses a Python function as a predicate.")

--- a/src/pyrauli/_core/bindings.cpp
+++ b/src/pyrauli/_core/bindings.cpp
@@ -29,7 +29,7 @@ using SchedulingPolicyPtr = std::shared_ptr<SchedulingPolicy>;
 using CoeffTruncatorPtr = std::shared_ptr<CoefficientTruncator<coeff_t>>;
 using WeightTruncatorPtr = std::shared_ptr<WeightTruncator>;
 using NeverTruncatorPtr = std::shared_ptr<NeverTruncator>;
-using KeepNTruncatorPtr = std::shared_ptr<KeepNTruncator>;
+using KeepNTruncatorPtr = std::shared_ptr<KeepNTruncator<coeff_t>>;
 using NeverPolicyPtr = std::shared_ptr<NeverPolicy>;
 using AlwaysBeforePolicyPtr = std::shared_ptr<AlwaysBeforeSplittingPolicy>;
 using AlwaysAfterPolicyPtr = std::shared_ptr<AlwaysAfterSplittingPolicy>;
@@ -212,10 +212,10 @@ PYBIND11_MODULE(_core, m) {
 	py::class_<NeverTruncator, Truncator<coeff_t>, NeverTruncatorPtr>(m, "NeverTruncator",
 									  "A truncator that never removes any terms.")
 		.def(py::init<>());
-	py::class_<KeepNTruncator, KeepNTruncator<coeff_t>, KeepNTruncatorPtr>(
+	py::class_<KeepNTruncator<coeff_t>, Truncator<coeff_t>, KeepNTruncatorPtr>(
 		m, "KeepNTruncator",
 		"A truncator that removes least significant Pauli Terms, when their numbers is above a threshold.")
-		.def(py::init<>());
+		.def(py::init<std::size_t>());
 	py::class_<LambdaTruncator, Truncator<coeff_t>, LambdaTruncatorPtr>(
 		m, "LambdaTruncator", "A truncator that uses a Python function as a predicate.")
 		.def(py::init<LambdaPredicate_t>());

--- a/src/pyrauli/converters.py
+++ b/src/pyrauli/converters.py
@@ -7,7 +7,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.quantum_info import SparsePauliOp
 import pyrauli
 
-def from_qiskit(qiskit_obj, noise_model: pyrauli.NoiseModel = None):
+def from_qiskit(qiskit_obj, noise_model: pyrauli.NoiseModel = None, reverse=False):
     """
     Converts a Qiskit object to its pyrauli equivalent.
 
@@ -21,7 +21,7 @@ def from_qiskit(qiskit_obj, noise_model: pyrauli.NoiseModel = None):
     if isinstance(qiskit_obj, QuantumCircuit):
         return from_qiskit_qc(qiskit_obj, noise_model=noise_model)
     elif isinstance(qiskit_obj, SparsePauliOp):
-        return from_qiskit_obs(qiskit_obj)
+        return from_qiskit_obs(qiskit_obj, reverse=reverse)
     else:
         raise ValueError(f"Can't convert object of type {type(qiskit_obj)} to pyrauli object.")
 
@@ -51,7 +51,7 @@ def from_qiskit_qc(qiskit_circuit: QuantumCircuit, noise_model: pyrauli.NoiseMod
 
     return pyrauli_circuit
 
-def from_qiskit_obs(qiskit_obs: SparsePauliOp) -> pyrauli.Observable:
+def from_qiskit_obs(qiskit_obs: SparsePauliOp, reverse=False) -> pyrauli.Observable:
     """
     Translates a Qiskit SparsePauliOp to a pyrauli.Observable.
     """
@@ -59,6 +59,11 @@ def from_qiskit_obs(qiskit_obs: SparsePauliOp) -> pyrauli.Observable:
     for pauli_string, coeff in zip(qiskit_obs.paulis, qiskit_obs.coeffs):
         if coeff.imag != 0.:
             logging.warning("pyrauli observables don't support complex coefficients.")
-        pt = pyrauli.PauliTerm(pauli_string.to_label(), float(coeff.real))
+
+        ps = pauli_string.to_label()
+        if reverse:
+            ps = ps[::-1]
+
+        pt = pyrauli.PauliTerm(ps, float(coeff.real))
         pts.append(pt)
     return pyrauli.Observable(pts)

--- a/src/pyrauli/estimator.py
+++ b/src/pyrauli/estimator.py
@@ -122,7 +122,7 @@ class PyrauliEstimator(BaseEstimatorV2):
         """
         exp_values = []
         for obs in observables:
-                pyrauli_obs = from_qiskit(obs)
+                pyrauli_obs = from_qiskit(obs, reverse=True)
                 final_observable = pyrauli_circuit.run(pyrauli_obs)
                 exp_values.append(final_observable.expectation_value())
         return exp_values


### PR DESCRIPTION
* Added a new `KeepNTruncator` to manage complexity
* Fixed qubit ordering not matching qiskit one when using the qiskit estimator and backends.